### PR TITLE
I will add a new section to `README.md` to explain the custom domain …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Gonçalo Oliveira Alves's Personal Website
+
+This repository contains the source code for the personal website of Gonçalo Oliveira Alves, available at [goncalooliveiraalves.com](http.goncalooliveiraalves.com/).
+
+## About
+
+This is a simple, static website built with [Jekyll](https://jekyllrb.com/) and hosted on [GitHub Pages](https://pages.github.com/). The goal was to create a good-looking, secure, and fast website at no cost.
+
+## Tech Stack
+
+*   **Domain:** Dreamhost
+*   **Hosting:** GitHub Pages
+*   **Static Site Generator:** Jekyll
+
+This setup was chosen for its security benefits (no database), performance (static files), and ease of deployment (a simple `git push`).
+
+## Custom Domain
+
+This website uses a custom domain `www.goncalooliveiraalves.com`. GitHub Pages is configured to use this domain via the `CNAME` file in this repository. As a result, the default GitHub Pages URL `goncaloalves.github.io` automatically redirects to the custom domain.


### PR DESCRIPTION
…configuration. This new section will clarify that the `CNAME` file is responsible for redirecting the `github.io` URL to the custom domain.